### PR TITLE
changed url for https to include "messaging"

### DIFF
--- a/reference/security/connect_devices_apps_gw.md
+++ b/reference/security/connect_devices_apps_gw.md
@@ -31,7 +31,7 @@ To connect device, application, and gateway clients to your {{site.data.keyword.
 
 ### HTTP REST API connection URL
 
-<pre class="pre"><code class="hljs">https://<var class="keyword varname">orgId</var>.internetofthings.ibmcloud.com/api/v0002/device/types/<var class="keyword varname">typeId</var>/devices/<var class="keyword varname">deviceId</var>/events/<var class="keyword varname">eventId</var></code></pre>
+<pre class="pre"><code class="hljs">https://<var class="keyword varname">orgId</var>.messaging.internetofthings.ibmcloud.com/api/v0002/device/types/<var class="keyword varname">typeId</var>/devices/<var class="keyword varname">deviceId</var>/events/<var class="keyword varname">eventId</var></code></pre>
 {: codeblock}
 
 **Notes**


### PR DESCRIPTION
Per chat with Tom Klapiscak,  the endpoint https://orgId.internetofthings.ibmcloud.com/api/v0002/device/types/typeId/devices/deviceId/events/eventId for HTTP messaging  was deprecated a while ago. These days, customers must including "messaging" in the url.  Refer to https://console.bluemix.net/docs/services/IoT/applications/api.html#api