### PR TITLE
Update manage_groups.md

### DIFF
--- a/manage_groups.md
+++ b/manage_groups.md
@@ -19,6 +19,8 @@ lastupdated: "2018-04-21"
 You can use {{site.data.keyword.iot_full}} groups to grant members and API keys access to specific devices. After you create a group and add devices to it, you add members and API keys to the group and assign them roles within the group. The combination of roles and groups determines which devices the users and API keys can access, and the actions that they can perform on the devices.
 {: shortdesc}
 
+Prerequisite: You must have the administrator role. For details about how to manage your role, see [Managing user roles](https://console.bluemix.net/docs/services/IoT/managing_user_roles.html#managing-user-roles)
+
 You can manage groups by using the {{site.data.keyword.iot_short_notm}} dashboard user interface or by using the {{site.data.keyword.iot_short_notm}} access control APIs.
 
 **Important:** The groups feature in the {{site.data.keyword.iot_short_notm}} UI is available only as part of a limited beta program. Future updates might include changes that are incompatible with the current version of this feature. Try it out and [let us know what you think ![External link icon](../../icons/launch-glyph.svg)](https://developer.ibm.com/answers/smart-spaces/17/internet-of-things.html){: new_window}.

--- a/manage_groups.md
+++ b/manage_groups.md
@@ -2,7 +2,7 @@
 
 copyright:
 years: 2018
-lastupdated: "2018-04-21"
+lastupdated: "2018-06-21"
 
 ---
 
@@ -16,12 +16,12 @@ lastupdated: "2018-04-21"
 # Managing groups (Beta)
 {: #groups_overview}
 
-You can use {{site.data.keyword.iot_full}} groups to grant members and API keys access to specific devices. After you create a group and add devices to it, you add members and API keys to the group and assign them roles within the group. The combination of roles and groups determines which devices the users and API keys can access, and the actions that they can perform on the devices.
+Users with the administrator role can use {{site.data.keyword.iot_full}} groups to grant members and API keys access to specific devices. After you create a group and add devices to it, you add members and API keys to the group and assign them roles within the group. The combination of roles and groups determines which devices the users and API keys can access, and the actions that they can perform on the devices.
 {: shortdesc}
 
-Prerequisite: You must have the administrator role. For details about how to manage your role, see [Managing user roles](https://console.bluemix.net/docs/services/IoT/managing_user_roles.html#managing-user-roles)
-
 You can manage groups by using the {{site.data.keyword.iot_short_notm}} dashboard user interface or by using the {{site.data.keyword.iot_short_notm}} access control APIs.
+
+For details about how to manage roles, see [Managing user roles](managing_user_roles.html#managing-user-roles)
 
 **Important:** The groups feature in the {{site.data.keyword.iot_short_notm}} UI is available only as part of a limited beta program. Future updates might include changes that are incompatible with the current version of this feature. Try it out and [let us know what you think ![External link icon](../../icons/launch-glyph.svg)](https://developer.ibm.com/answers/smart-spaces/17/internet-of-things.html){: new_window}.
 


### PR DESCRIPTION
Per a ticket from a client whose role is 'developer', he failed to create a group because of 'not allowed' permission. I, as an 'admin', can create a group successfully. So I'm wondering whether the KC herein should mention "Users must have the admin role"? Please reject my submit if you disagree. Thank you.